### PR TITLE
chore: update swiftlint path (ZEL-3238)

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -71,7 +71,7 @@ if [ ! -f $SONAR_SCANNER_CMD ]; then
 fi
 
 SWIFTLINT_REPORT=$DEPLOY_DIR/swiftlint.json
-Pods/SwiftLint/swiftlint lint --reporter json > $SWIFTLINT_REPORT || echo "Failure..."
+swiftlint lint --reporter json > $SWIFTLINT_REPORT || echo "Failure..."
 
 PR_ARGS=""
 if [ ! -z "${BITRISE_PULL_REQUEST}" ]; then


### PR DESCRIPTION
Mise à jour du path de `swiftlint`. 

Avant installé avec `Cocoapods`, il est maintenant installé avec `Homebrew` dans la CI